### PR TITLE
Add seq string and cigar string to get aln object

### DIFF
--- a/js-local-bam.js
+++ b/js-local-bam.js
@@ -746,7 +746,11 @@ readBinaryBAM.prototype.getAlns =
                         for (var i = 0; i < aln_blksizes.length; i++){
                             p.seek(offset);
                             p.aln_end = offset + aln_blksizes[i];
-                            alns.push(p.parse('aln'));
+                            var aln = p.parse('aln');
+                            aln.head.cigarArr = bamRthis.cigarInfo(aln);
+                            aln.head.cigarStr = aln.head.cigarArr.map(function(c) { return c.op_len + c.op;}).join();
+                            aln.head.seqStr = bamRthis.getSeq(aln);
+                            alns.push(aln);
                             offset = p.tell() + 4;
                         };
                     };

--- a/js-local-bam.js
+++ b/js-local-bam.js
@@ -751,7 +751,10 @@ readBinaryBAM.prototype.getAlns =
                             aln.head.cigarArr = bamRthis.cigarInfo(aln);
                             aln.head.cigarStr = aln.head.cigarArr.map(function(c) { return c.op_len + c.op;}).join();
                             aln.head.seqStr = bamRthis.getSeq(aln);
-                            alns.push(aln);
+                            var s = aln.head.pos,
+                                e = s + aln.head.l_seq;
+                            if ((s > beg) && (s <= end) || (e > beg) && (e <= end)) // filter on exact region
+                                alns.push(aln);
                             offset = p.tell() + 4;
                         };
                     };

--- a/js-local-bam.js
+++ b/js-local-bam.js
@@ -747,6 +747,7 @@ readBinaryBAM.prototype.getAlns =
                             p.seek(offset);
                             p.aln_end = offset + aln_blksizes[i];
                             var aln = p.parse('aln');
+                            aln.head.pos += 1; // add 1 for the change from BAM to SAM format
                             aln.head.cigarArr = bamRthis.cigarInfo(aln);
                             aln.head.cigarStr = aln.head.cigarArr.map(function(c) { return c.op_len + c.op;}).join();
                             aln.head.seqStr = bamRthis.getSeq(aln);


### PR DESCRIPTION
The get aln object that is returned has the seq and cigar as uint8 arrays. This adds an 3 extra fields to make human readable versions seq and cigar available to the user.

New Fields:
- seqStr - sequence as a human readable string
- cigarStr - the cigar as a human readable string
- cigarArr - the cigar ops as a human readable array
